### PR TITLE
COOK-1272 Replace reference to deprecated epel_release version on CentOS...

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,7 +24,7 @@ default[:yum][:installonlypkgs]
 
 default['yum']['epel_release'] = case node['platform_version'].to_i
                                   when 6
-                                    "6-6"
+                                    "6-7"
                                   when 5
                                     "5-4"
                                   when 4


### PR DESCRIPTION
.../RHEL 6.

https://bugzilla.redhat.com/show_bug.cgi?id=820360
