### PR TITLE
Changed 'epel_release' default attribute for 6.X to 6-7

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,7 +24,7 @@ default[:yum][:installonlypkgs]
 
 default['yum']['epel_release'] = case node['platform_version'].to_i
                                   when 6
-                                    "6-5"
+                                    "6-7"
                                   when 5
                                     "5-4"
                                   when 4


### PR DESCRIPTION
Fix for 1272 where Cent/RHEL 6.x can't install epel
