### PR TITLE
Update README.md to have better yum_repository example

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ repo is added.
 ``` ruby
 # add the Zenoss repository
 yum_repository "zenoss" do
-  name "Zenoss Stable repo"
+  repo_name "zenoss"
+  description "Zenoss Stable repo"
   url "http://dev.zenoss.com/yum/stable/"
   key "RPM-GPG-KEY-zenoss"
   action :add


### PR DESCRIPTION
The existing sample in the README.md file for yum_repository "zenoss" is incorrect:
- updated 'name' attribute to be 'repo_name'
- used a better name since it is the filename of the repository
- added 'description' so the "name" field inside the generated file is filled in

I have a license on file, but didn't open an issue since it wasn't changing the cookbook directly.
