### PR TITLE
Fixes [COOK-1908], wrong arch in repoforge filename

### DIFF
--- a/recipes/repoforge.rb
+++ b/recipes/repoforge.rb
@@ -21,7 +21,7 @@ include_recipe "yum::epel"
 
 major = node['platform_version'].to_i
 
-if node['kernel']['machine'] == "i686"
+if node['kernel']['machine'] == "i686" && major == 5
     arch = "i386"
 else
     arch = node['kernel']['machine']


### PR DESCRIPTION
Addresses: http://tickets.opscode.com/browse/COOK-1908
