### PR TITLE
COOK-2360: don't overwrite the epel repo if it already exists

### DIFF
--- a/recipes/epel.rb
+++ b/recipes/epel.rb
@@ -30,5 +30,5 @@ yum_repository "epel" do
   mirrorlist node['yum']['epel']['url']
   includepkgs node['yum']['epel']['includepkgs']
   exclude node['yum']['epel']['exclude']
-  action platform?('amazon') ? [:add, :update] : :create
+  action platform?('amazon') ? [:add, :update] : :add
 end


### PR DESCRIPTION
commit 89e6c61b559caa1878eebf374ba971842111 changed the behavior of
the epel recipe to create instead of adding the epel repo file.  This
caused the file to be overwritten which changes the behavior from
previous.

COOK-2196 makes no mention of the need for this change.
