### PR TITLE
Stop recipe from using url as mirrorlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ EPEL attributes used in the `yum::epel` recipe, see
 * `yum['epel']['key']`
     - Name of the GPG key used for the repo.
 
+* `yum['epel']['baseurl']`
+    - Base URL to an EPEL mirror.
+
 * `yum['epel']['url']`
     - URL to the EPEL mirrorlist.
 

--- a/attributes/epel.rb
+++ b/attributes/epel.rb
@@ -21,9 +21,11 @@
 case node['platform']
 when "amazon"
   default['yum']['epel']['url'] = "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-6&arch=$basearch"
+  default['yum']['epel']['baseurl'] = ""
   default['yum']['epel']['key'] = "RPM-GPG-KEY-EPEL-6"
 else
   default['yum']['epel']['url'] = "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-#{node['platform_version'].to_i}&arch=$basearch"
+  default['yum']['epel']['baseurl'] = ""
 
   if node['platform_version'].to_i >= 6
     default['yum']['epel']['key'] = "RPM-GPG-KEY-EPEL-6"

--- a/recipes/epel.rb
+++ b/recipes/epel.rb
@@ -27,6 +27,7 @@ end
 yum_repository "epel" do
   description "Extra Packages for Enterprise Linux"
   key node['yum']['epel']['key']
+  url node['yum']['epel']['baseurl']
   mirrorlist node['yum']['epel']['url']
   includepkgs node['yum']['epel']['includepkgs']
   exclude node['yum']['epel']['exclude']


### PR DESCRIPTION
- Changed all references to epel['url'] to epel['mirrorlisturl']
  - Modified recipe to correctly use attribute epel['url']
  - Make recipe stop assuming that the url attribute was the same
    as a mirrorlist.
