### PR TITLE
[COOK-2663] - Repo metadata_expire ability

### DIFF
--- a/providers/repository.rb
+++ b/providers/repository.rb
@@ -113,7 +113,8 @@ def repo_config
                 :bootstrapurl => new_resource.bootstrapurl,
                 :includepkgs => new_resource.includepkgs,
                 :exclude => new_resource.exclude,
-                :priority => new_resource.priority
+                :priority => new_resource.priority,
+                :metadata_expire => new_resource.metadata_expire
               })
     if new_resource.make_cache
       notifies :run, "execute[yum-makecache]", :immediately

--- a/resources/repository.rb
+++ b/resources/repository.rb
@@ -33,6 +33,7 @@ attribute :make_cache, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :includepkgs, :kind_of => String, :default => nil
 attribute :exclude, :kind_of => String, :default => nil
 attribute :priority, :kind_of => [Integer, String], :default => nil
+attribute :metadata_expire, :kind_of => [Integer, String], :default => nil
 
 def initialize(*args)
   super

--- a/templates/default/repo.erb
+++ b/templates/default/repo.erb
@@ -33,3 +33,6 @@ exclude=<%= @exclude %>
 <% if @priority %>
 priority=<%= @priority %>
 <% end %>
+<% if @metadata_expire %>
+metadata_expire=<%= @metadata_expire%>
+<% end %>


### PR DESCRIPTION
Added in the ability to specify the repo metadata_expire setting in the .repo file. This will allow someone to use an internal repo and have a lower expire time, but still leave public repos at a higher expire time to avoid ddos mirrors.
