### PR TITLE
Add extra type param to provider for the resulting yum.repo output

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,8 @@ repo is added.
 - bootstrapurl: Optional, bootstrapurl
 - make_cache: Optional, Default is `true`, if `false` then `yum -q
   makecache` will not be ran
+- metadata_expire: Optional, Default is nil (or not applied)
+- type: Optional, Default is nil (or not applied)
 
 *Note*: When using both url (to set baseurl) and mirrorlist, it is probably a
 good idea to also install the fastestmirror plugin, and use

--- a/providers/repository.rb
+++ b/providers/repository.rb
@@ -114,7 +114,8 @@ def repo_config
                 :includepkgs => new_resource.includepkgs,
                 :exclude => new_resource.exclude,
                 :priority => new_resource.priority,
-                :metadata_expire => new_resource.metadata_expire
+                :metadata_expire => new_resource.metadata_expire,
+                :type => new_resource.type
               })
     if new_resource.make_cache
       notifies :run, "execute[yum-makecache]", :immediately

--- a/resources/repository.rb
+++ b/resources/repository.rb
@@ -34,6 +34,7 @@ attribute :includepkgs, :kind_of => String, :default => nil
 attribute :exclude, :kind_of => String, :default => nil
 attribute :priority, :kind_of => [Integer, String], :default => nil
 attribute :metadata_expire, :kind_of => [Integer, String], :default => nil
+attribute :type, :kind_of => String, :default => nil
 
 def initialize(*args)
   super

--- a/templates/default/repo.erb
+++ b/templates/default/repo.erb
@@ -36,3 +36,6 @@ priority=<%= @priority %>
 <% if @metadata_expire %>
 metadata_expire=<%= @metadata_expire%>
 <% end %>
+<% if @type %>
+type=<%= @type%>
+<% end %>


### PR DESCRIPTION
I use the Nexus repository to host yum repos and they require that the yum config contain a type=rpm-md to make the hosted repo work.
