### PR TITLE
[COOK-3015] Fixed minitest issue.

### DIFF
--- a/files/default/tests/minitest/default_test.rb
+++ b/files/default/tests/minitest/default_test.rb
@@ -23,6 +23,6 @@ describe "yum::default" do
   include Helpers::YumTest
 
   it "Default recipe does nothing, so default_test does nothing" do
-  	# pending
+    # pending
   end
 end

--- a/files/default/tests/minitest/test_test.rb
+++ b/files/default/tests/minitest/test_test.rb
@@ -51,10 +51,9 @@ describe "yum::test" do
     it "enables the repoforge repository" do
       assert(repo_enabled("rpmforge"))
     end
-	end
+  end
 
   describe "cook-2121" do
-
     it 'doesnt update the zenos-add.repo file if it exists' do
       assert File.zero?('/etc/yum.repos.d/zenoss-add.repo')
     end

--- a/recipes/yum.rb
+++ b/recipes/yum.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: yum
-# Recipe:: yum 
+# Recipe:: yum
 #
 # Copyright 2011, Eric G. Wolfe
 # Copyright 2011, Opscode, Inc.


### PR DESCRIPTION
The "pending" statement in `files/default/tests/minitest/default_test.rb` was causing errors for us (see below).  I have commented it out for the meantime, and fixed a few whitespace anomalies.

```
  1) Error:
yum::default#test_0001_Default recipe does nothing, so default_test does nothing:
NameError: undefined local variable or method `pending' for #<#<Class:0x00000001dd3960>:0x00000002439660>
    /var/chef/minitest/yum/default_test.rb:26:in `block (2 levels) in <top (required)>'
```
