### PR TITLE
[COOK-3275] LWRP repository.rb :add method fails to create yum repo in some cases which causes :update to fail  (Amazon rehl)

### DIFF
--- a/providers/repository.rb
+++ b/providers/repository.rb
@@ -68,7 +68,7 @@ action :update do
   else
     Chef::Log.error "Repo /etc/yum.repos.d/#{new_resource.repo_name}.repo does not exist, you must create it first"
   end
-  if repos[new_resource.repo_name]['enabled'].to_i != new_resource.enabled
+  if !repos.has_key?(new_resource.repo_name) || repos[new_resource.repo_name]['enabled'].to_i != new_resource.enabled
     Chef::Log.info "Updating #{new_resource.repo_name} repository in /etc/yum.repos.d/#{new_resource.repo_name}.repo (setting enabled=#{new_resource.enabled})"
     repo_config
   else


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-3275

A little background of the problem (and strange problem I would say):

I deployed new machine with latest Amazon AMI, assigned a role which included yum rehl repo setup and run chef-client. Everything worked as expected, I noticed epel.repo file under /etc/yum.repos.d dir. 

Then I decided to use yum cookbook on one of our existing images with some preinstalled binaries and stuff. I was surprised that chef-client failed early on yum cookbook with the following message:

FATAL: NoMethodError: yum_repository[epel](yum::epel line 27) had an error: NoMethodError: undefined method `[]' for nil:NilClass

Cookbook Trace:

/var/chef/cache/cookbooks/yum/providers/repository.rb:71:in `block in class_from_file'

After some debugging time I figured that :add method didn't run template resource from repo_config function.. It was skipped for some reason, even though /etc/yum.repos.d didn't have epel.repo file.. I was running chef-client in debugging mode ( -l debug ) and that proved my theory about skipped template resource call..
- yum_repository[epel] action add[2013-06-03T18:27:35+00:00] WARN: Cloning resource attributes for yum_key[RPM-GPG-KEY-EPEL-6] from prior resource (CHEF-3694)
  [2013-06-03T18:27:35+00:00] WARN: Previous yum_key[RPM-GPG-KEY-EPEL-6]: /var/chef/cache/cookbooks/yum/recipes/epel.rb:22:in `from_file'
  [2013-06-03T18:27:35+00:00] WARN: Current  yum_key[RPM-GPG-KEY-EPEL-6]: /var/chef/cache/cookbooks/yum/providers/repository.rb:85:in`repo_config'
  (up to date)
  - yum_repository[epel] action update[2013-06-03T18:27:35+00:00] ERROR: Repo /etc/yum.repos.d/epel.repo does not exist, you must create it first

Notice no mention of template recourse call between add and update actions!!!

Now, this whole repo_config method call from most actions inside LWRP seems a little strange to me and I would like some explanations why that template resource was skipped during chef-client run. I have a theory that during chef-client run all actions are precomplied and since we use 2 [:add, :update] for Amazon (reason?) and since they both use the same repo_config method (and the same call to template as the result ) only one of those template calls will execute...

In the meanwhile I added super simple check to the update action inside LWRP which solves the problem, but still keeps me thinking why :add action would fail to execute template resource..

Sorry for long description..
