### PR TITLE
[COOK-3689] Prevent warning of resource cloning

### DIFF
--- a/providers/repository.rb
+++ b/providers/repository.rb
@@ -86,9 +86,9 @@ def repo_config
       key new_resource.key
     end
   end
-  #get the metadata
+  #get the metadata for this repo only
   execute "yum-makecache-#{new_resource.repo_name}" do
-    command "yum -q makecache"
+    command "yum -q makecache --disablerepo=* --enablerepo=#{new_resource.repo_name}"
     action :nothing
   end
   #reload internal Chef yum cache


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3689

When using the `key` and then the `repository` LWRP using the name of the key resource to define the key attribute implicitly, the repository LWRP will create (clone) the key resource resulting in a warn log message for CHEF-3694. 
The same warning will also appear if you define multiple repository resources with each resource calling the `yum-makecache` execute  and the `reload-internal-yum-cache`  ruby-block resource.

To prevent this i suffixed the resources with the name of the repo.

The second commit will change the behaviour of the `yum-makecache` resource to get the metadata only for the current repository. In case of multiple repositories this is a lot faster.
