### PR TITLE
[COOK-3734] Squash clone warnings for gnupg pkg

### DIFF
--- a/providers/key.rb
+++ b/providers/key.rb
@@ -27,9 +27,15 @@ action :add do
     Chef::Log.info "Adding #{new_resource.key} GPG key to /etc/pki/rpm-gpg/"
 
     if node['platform_version'].to_i <= 5
-      package "gnupg"
+      package_name = "gnupg"
     elsif node['platform_version'].to_i >= 6
-      package "gnupg2"
+      package_name = "gnupg2"
+    end
+
+    begin
+      resource_collection.find(:package => package_name)
+    rescue Chef::Exceptions::ResourceNotFound
+      package package_name
     end
 
     execute "import-rpm-gpg-key-#{new_resource.key}" do


### PR DESCRIPTION
When installing multiple keys using the key provider, you will get a
clone warning for each additional key being installed. This only
declares the gnupg package resource once if it doesn't exist.

Fixes https://tickets.opscode.com/browse/COOK-3734
