### PR TITLE
[COOK-4164] Revert yum_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ NOTES
 WARNING: Yum cookbook version 3.0.0 and above contain non-backwards
 compatible breaking changes and will not work with cookbooks written
 against the 2.x and 1.x series. Changes have been made to the
-yum_repository resource, and the yum_key resource has been eliminated
-entirely. Recipes have been eliminated and moved into their own
+yum_repository resource. Recipes have been eliminated and moved into their own
 cookbooks. Please lock yum to the 2.x series in your Chef environments
 until all dependent cookbooks have been ported.
 
@@ -26,11 +25,43 @@ Requirements
 Resources/Providers
 -------------------
 
+### yum_key
+This LWRP handles importing GPG keys for YUM repositories. Keys can be
+imported by the `url` parameter or placed in `/etc/pki/rpm-gpg/` by a
+recipe and then installed with the LWRP without passing the URL.
+
+#### Actions
+- :add: installs the GPG key into `/etc/pki/rpm-gpg/`
+- :remove: removes the GPG key from `/etc/pki/rpm-gpg/`
+
+#### Attribute Parameters
+- key: name attribute. The name of the GPG key to install.
+- url: if the key needs to be downloaded, the URL providing the download.
+
+#### Example
+
+``` ruby
+# add the Zenoss GPG key
+yum_key "RPM-GPG-KEY-zenoss" do
+  url "http://dev.zenoss.com/yum/RPM-GPG-KEY-zenoss"
+  action :add
+end
+
+# remove Zenoss GPG key
+yum_key "RPM-GPG-KEY-zenoss" do
+  action :remove
+end
+```
+
 ### yum_repository
 This resource manages a yum repository configuration file at
 /etc/yum.repos.d/`repositoryid`.repo. When the file needs to be
 repaired, it calls yum-makecache so packages in the repo become
 available to the next resource.
+
+#### Attribute Parameters
+- key: name attribute. The name of the GPG key to install.
+- url: if the key needs to be downloaded, the URL providing the download.
 
 #### Actions
 - `:create` - creates a repository file and builds the repository listing
@@ -62,8 +93,8 @@ available to the next resource.
 * `gpgkey` - A URL pointing to the ASCII-armored GPG key file for the
   repository. This option is used if yum needs a public key to verify
   a package and the required key hasn't been imported into the RPM
-  database. If this option is set, yum will automatically import the
-  key from the specified URL.
+  database. If `assumeyes` is true and `gpgkey` is set, yum will
+  automatically import the key from the specified URL.
 * `http_caching` - Either 'all', 'packages', or 'none'. Determines how
   upstream HTTP caches are instructed to handle any HTTP downloads
   that Yum does. Defaults to 'all'

--- a/providers/key.rb
+++ b/providers/key.rb
@@ -1,0 +1,79 @@
+# Encoding: utf-8
+#
+# Cookbook Name:: yum
+# Provider:: key
+#
+# Copyright 2010, Tippr Inc.
+# Copyright 2011, Opscode, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+def whyrun_supported?
+  true
+end
+
+action :add do
+  unless ::File.exists?("/etc/pki/rpm-gpg/#{new_resource.key}")
+    Chef::Log.info "Adding #{new_resource.key} GPG key to /etc/pki/rpm-gpg/"
+
+    if node['platform_version'].to_i <= 5
+      package 'gnupg'
+    elsif node['platform_version'].to_i >= 6
+      package 'gnupg2'
+    end
+
+    execute "import-rpm-gpg-key-#{new_resource.key}" do
+      command "rpm --import /etc/pki/rpm-gpg/#{new_resource.key}"
+      action :nothing
+      not_if <<-EOH
+    function packagenames_for_keyfile() {
+      local filename="$1"
+      gpg \
+        --with-fingerprint \
+        --with-colons \
+        --fixed-list-mode \
+        "$filename" \
+      | gawk -F: '/^pub/ { print tolower(sprintf("gpg-pubkey-%s-%x\\n", substr($5, length($5)-8+1), $6)) }'
+    }
+
+    for pkgname in $(packagenames_for_keyfile "/etc/pki/rpm-gpg/#{new_resource.key}"); do
+      if [[ $pkgname ]] && ! rpm -q $pkgname ; then
+        exit 1;
+      fi;
+    done
+
+    exit 0
+    EOH
+    end
+
+    # download the file if necessary
+    remote_file "/etc/pki/rpm-gpg/#{new_resource.key}" do
+      source new_resource.url
+      mode '0644'
+      notifies :run, "execute[import-rpm-gpg-key-#{new_resource.key}]", :immediately
+      not_if { new_resource.url.nil? }
+    end
+
+  end
+end
+
+action :remove do
+  if ::File.exists?("/etc/pki/rpm-gpg/#{new_resource.key}")
+    Chef::Log.info "Removing #{new_resource.key} key from /etc/pki/rpm-gpg/"
+    file "/etc/pki/rpm-gpg/#{new_resource.key}" do
+      action :delete
+    end
+    new_resource.updated_by_last_action(true)
+  end
+end

--- a/resources/key.rb
+++ b/resources/key.rb
@@ -1,0 +1,30 @@
+# Encoding: utf-8
+#
+# Cookbook Name:: yum
+# Resource:: key
+#
+# Copyright 2011, Opscode, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+actions :add, :remove
+default_action :add
+
+attribute :key, :kind_of => String, :name_attribute => true
+attribute :url, :kind_of => String, :default => nil
+
+def initialize(*args)
+  super
+  @action = :add
+end


### PR DESCRIPTION
The 3.0 yum removes the yum_key LWRP on the basis that yum will
automatically import gpgkeys if set to a remote URL. This is only true,
if `assumeyes` (Assume Yes) is set globally in the central yum.conf.

There is no "Assume Yes" for importing GPG keys, or for individual repo
files. Therefore, setting `assumeyes` globally is an, all or nothing,
action that would change default behavior for all other yum commands,
e.g. `yum upgrade`.

Proposed restoration of functionality of yum_key LWRP from commitish
11d24bfea28455e55484ecbce407eebdb92b8adc. Otherwise, the yum_repository
LWRP could be modified to accommodate the shortcomings of yum and the
importation of GPG keys when `assumeyes` is set to false globally.

Rubocop:
- Always use hash rockets in hashes.

Foodcritic:
- FC023: Prefer conditional attributes: ./providers/key.rb
