### PR TITLE
Fix validation of 'metadata_expire' option to match documentation

### DIFF
--- a/resources/globalconfig.rb
+++ b/resources/globalconfig.rb
@@ -67,7 +67,7 @@ attribute :localpkg_gpgcheck, :kind_of => [TrueClass, FalseClass], :default => n
 attribute :logfile, :kind_of => String, :regex => /.*/, :default => '/var/log/yum.log'
 attribute :max_retries, :kind_of => String, :regex => /^\d+$/, :default => nil
 attribute :mdpolicy, :kind_of => String, :equal_to => %w{ instant group:primary group:small group:main group:all }, :default => nil
-attribute :metadata_expire, :kind_of => String, :regex => /^\d+$/, :default => nil
+attribute :metadata_expire, :kind_of => String, :regex => [/^\d+$/, /^\d+[mhd]$/, /never/], :default => nil
 attribute :mirrorlist_expire, :kind_of => String, :regex => /^\d+$/, :default => nil
 attribute :multilib_policy, :kind_of => String, :equal_to => %w{ all best }, :default => nil
 attribute :obsoletes, :kind_of => [TrueClass, FalseClass], :default => '1'

--- a/resources/repository.rb
+++ b/resources/repository.rb
@@ -38,7 +38,7 @@ attribute :include_config, :kind_of => String, :regex => /.*/, :default => nil
 attribute :includepkgs, :kind_of => String, :regex => /.*/, :default => nil
 attribute :keepalive, :kind_of => [TrueClass, FalseClass], :default => nil
 attribute :max_retries, :kind_of => String, :regex => /.*/, :default => nil
-attribute :metadata_expire, :kind_of => String, :regex => [/^\d+$/, /^\d+d$/, /never/], :default => nil
+attribute :metadata_expire, :kind_of => String, :regex => [/^\d+$/, /^\d+[mhd]$/, /never/], :default => nil
 attribute :mirrorexpire, :kind_of => String, :regex => /.*/, :default => nil
 attribute :mirrorlist, :kind_of => String, :regex => /.*/, :default => nil
 attribute :mirror_expire, :kind_of => String, :regex => /^\d+$/, :default => nil


### PR DESCRIPTION
At present, it limits this option to only the 'd' modifier despite yum
also supporting 'm' and 'h' for minutes and hours respectively.
