### PR TITLE
allow activation of arbitrary plugins within a repository

### DIFF
--- a/providers/repository.rb
+++ b/providers/repository.rb
@@ -36,6 +36,15 @@ action :create  do
   # notifies timing to :immediately for the same reasons. Remove both
   # of these when dropping Chef 10 support.
 
+  # Add the fastest mirror plugin to the enabled plugins for backwards
+  # compatibility
+  case new_resource.fastestmirror_enabled
+    when true
+      new_resource.plugins << {'fastestmirror' => true}
+    when false
+      new_resource.plugins << {'fastestmirror' => false}
+  end
+
   template "/etc/yum.repos.d/#{new_resource.repositoryid}.repo" do
     if new_resource.source.nil?
       source 'repo.erb'

--- a/resources/repository.rb
+++ b/resources/repository.rb
@@ -56,6 +56,7 @@ attribute :sslclientcert, :kind_of => String, :regex => /.*/, :default => nil
 attribute :sslclientkey, :kind_of => String, :regex => /.*/, :default => nil
 attribute :sslverify, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :timeout, :kind_of => String, :regex => /^\d+$/, :default => nil
+attribute :plugins, :kind_of => Array, :default => []
 
 alias_method :url, :baseurl
 alias_method :keyurl, :gpgkey

--- a/templates/default/repo.erb
+++ b/templates/default/repo.erb
@@ -23,8 +23,10 @@ exclude=<%= @config.exclude %>
 <% if @config.failovermethod %>
 failovermethod=<%= @config.failovermethod %>
 <% end %>
-<% if @config.fastestmirror_enabled %>
-fastestmirror_enabled=<%= @config.fastestmirror_enabled %>
+<% @config.plugins.each do |plugin| %>
+<% plugin.each do |plugin_name, enabled_value| %>
+<%= plugin_name %>_enabled=<%= enabled_value %>
+<% end %>
 <% end %>
 <% if @config.gpgcheck %>
 gpgcheck=1


### PR DESCRIPTION
Allows other plugins, other than just fastestmirror, to be used within a repository resource.

My particular use case is an s3 plugin - https://github.com/seporaitis/yum-s3-iam

Without this change the Chef developer is forced to use other means to generate the repo file - e.g. template resource - outside of the yum cookbook.

Usage example
yum_repository 'repo' do
  # ...
  plugins       ['s3' => true, 'foo' => false, 'bar' => true]
end
