### PR TITLE
Adds releasever option (used by Amazon Linux) to the generated yum.conf

### DIFF
--- a/attributes/main.rb
+++ b/attributes/main.rb
@@ -76,6 +76,7 @@ default['yum']['main']['proxy_username'] = nil #  /.*/
 default['yum']['main']['username'] = nil #  /.*/
 default['yum']['main']['password'] = nil #  /.*/
 default['yum']['main']['recent'] = nil # /^\d+$/
+default['yum']['main']['releasever'] = nil #  /.*/
 default['yum']['main']['repo_gpgcheck'] = nil # [TrueClass, FalseClass]
 default['yum']['main']['reset_nice'] = nil # [TrueClass, FalseClass]
 default['yum']['main']['rpmverbosity'] = nil # %w{ info critical# emergency error warn debug }

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -29,5 +29,6 @@ yum_globalconfig '/etc/yum.conf' do
   installonlypkgs node['yum']['main']['installonlypkgs']
   installroot node['yum']['main']['installroot']
   distroverpkg node['yum']['main']['distroverpkg']
+  releasever node['yum']['main']['releasever']
   action :create
 end

--- a/resources/globalconfig.rb
+++ b/resources/globalconfig.rb
@@ -84,6 +84,7 @@ attribute :proxy, :kind_of => String, :regex => /.*/, :default => nil
 attribute :proxy_password, :kind_of => String, :regex => /.*/, :default => nil
 attribute :proxy_username, :kind_of => String, :regex => /.*/, :default => nil
 attribute :recent, :kind_of => String, :regex => /^\d+$/, :default => nil
+attribute :releasever, :kind_of => String, :regex => /.*/, :default => nil
 attribute :repo_gpgcheck, :kind_of => [TrueClass, FalseClass], :default => nil
 attribute :reset_nice, :kind_of => [TrueClass, FalseClass], :default => nil
 attribute :rpmverbosity, :kind_of => String, :equal_to => %w(info critical emergency error warn debug), :default => nil

--- a/templates/default/main.erb
+++ b/templates/default/main.erb
@@ -192,6 +192,9 @@ proxy_username=<%= @config.proxy_username %>
 <% if @config.recent %>
 recent=<%= @config.recent %>
 <% end %>
+<% if @config.releasever %>
+releasever=<%= @config.releasever %>
+<% end %>
 <% if @config.repo_gpgcheck %>
 repo_gpgcheck=<%= @config.repo_gpgcheck %>
 <% end %>


### PR DESCRIPTION
As instructed in this thread: https://forums.aws.amazon.com/thread.jspa?messageID=535192 users of Amazon Linux are advised to set a custom option `releasever=latest` in `yum.conf` to ensure the latest updates. I did not find a way to specify that with the current yum cookbook version.

Running yum cookbook actually breaks yum dependency resolution on newly created Amazon Linux instances because by default Amazon Linux come with this special option but then running Chef removes that option and then dependency conflicts start to arise.

Note that this value does not have to be the same as that of option `distroverpkg` (which sets the variable `$releasever`) - in fact setting `distroverpkg=latest` breaks things as that then generates some invalid URLs.

As I understand yum plugin developers are allowed to add custom options to yum, but the current implementation of `yum.conf` doesn't allow neither to specify custom options, nor to specify a custom template to be used in place of `main.erb`. Therefore I just added it in parallel to other `yum.conf` options.
