### PR TITLE
Fix issue with sslverify if set to false.

### DIFF
--- a/templates/default/main.erb
+++ b/templates/default/main.erb
@@ -222,7 +222,7 @@ sslclientcert=<%= @config.sslclientcert %>
 <% if @config.sslclientkey %>
 sslclientkey=<%= @config.sslclientkey %>
 <% end %>
-<% if @config.sslverify %>
+<% unless @config.sslverify.nil? %>
 sslverify=<%= @config.sslverify %>
 <% end %>
 <% if @config.syslog_device %>

--- a/templates/default/repo.erb
+++ b/templates/default/repo.erb
@@ -99,10 +99,8 @@ sslclientcert=<%= @config.sslclientcert %>
 <% if @config.sslclientkey %>
 sslclientkey=<%= @config.sslclientkey %>
 <% end %>
-<% if @config.sslverify %>
-sslverify=1
-<% else %>
-sslverify=0
+<% unless @config.sslverify.nil? %>
+sslverify=<%= @config.sslverify %>
 <% end %>
 <% if @config.timeout %>
 timeout=<%= @config.timeout %>


### PR DESCRIPTION
There should be a difference if @config.sslverify is set to false
instead of nil. In the latter case we should print "false" as we are
explicitly telling this repository to setup verification.

Also changes the [setting to True/False as per documentation](http://linux.die.net/man/5/yum.conf).
