### PR TITLE
set distroverpkg: nil on redhat

### DIFF
--- a/attributes/main.rb
+++ b/attributes/main.rb
@@ -11,6 +11,8 @@ when 'amazon'
   default['yum']['main']['distroverpkg'] = 'system-release'
 when 'scientific'
   default['yum']['main']['distroverpkg'] = 'sl-release'
+when 'redhat'
+  default['yum']['main']['distroverpkg'] = nil
 else
   default['yum']['main']['distroverpkg'] = "#{node['platform']}-release"
 end


### PR DESCRIPTION
Setting `distroverpkg=redhat-release` on RHEL 7 breaks Yum with such error:

```
Loaded plugins: amazon-id, rhui-lb
epel                                                                                                                                                       | 3.7 kB  00:00:00     
rhui-REGION-client-config-server-7                                                                                                                         | 2.9 kB  00:00:00     
https://rhui2-cds02.us-east-1.aws.ce.redhat.com/pulp/repos//content/dist/rhel/rhui/server/7/7.0-1.el7/x86_64/os/repodata/repomd.xml: [Errno 14] HTTPS Error 404 - Not Found
Trying other mirror.
https://rhui2-cds01.us-east-1.aws.ce.redhat.com/pulp/repos//content/dist/rhel/rhui/server/7/7.0-1.el7/x86_64/os/repodata/repomd.xml: [Errno 14] HTTPS Error 404 - Not Found
Trying other mirror.


 One of the configured repositories failed (Red Hat Enterprise Linux Server 7 (RPMs)),
 and yum doesn't have enough cached data to continue. At this point the only
 safe thing yum can do is fail. There are a few ways to work "fix" this:

     1. Contact the upstream for the repository and get them to fix the problem.

     2. Reconfigure the baseurl/etc. for the repository, to point to a working
        upstream. This is most often useful if you are using a newer
        distribution release than is supported by the repository (and the
        packages for the previous distribution release still work).

     3. Disable the repository, so yum won't use it by default. Yum will then
        just ignore the repository until you permanently enable it again or use
        --enablerepo for temporary usage:

            yum-config-manager --disable rhui-REGION-rhel-server-releases

     4. Configure the failing repository to be skipped, if it is unavailable.
        Note that yum will try to contact the repo. when it runs most commands,
        so will have to try and fail each time (and thus. yum will be be much
        slower). If it is a very temporary problem though, this is often a nice
        compromise:

            yum-config-manager --save --setopt=rhui-REGION-rhel-server-releases.skip_if_unavailable=true
```

As you can see the problem with `releasever` component, which detected as `7.0-1.el7` while it should be `7Server`

Seems since RHEL 6.3 there is no `redhat-release` package, it was dropped and replaced my more specific `redhat-release-server` for server distribution, `redhat-release-client` for desktop, and so on https://rhn.redhat.com/errata/RHEA-2012-0971.html

For compatibility `redhat-release` is provided by `redhat-release-server`, but this doesn't work for Yum

```
$ rpm -q --provides redhat-release-server
config(redhat-release-server) = 7.0-1.el7
redhat-release = 7.0-1.el7
redhat-release-server = 7.0-1.el7
redhat-release-server(x86-64) = 7.0-1.el7
system-release = 7.0-1.el7
system-release(releasever) = 7Server
```

Yes, i've tried to set `distroverpkg=system-release`, but this brings me the same error.

So only removing `distroverpkg` option from `yum.conf` drives Yum in a right way and `releasever` becomes `7Server`
