### PR TITLE
Add kitchen-digitalocean, kitchen-sync for cloud testing.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,8 @@ group :unit do
   gem 'chefspec',   '~> 4.0'
   gem 'berkshelf'
 end
+
+group :kitchen_cloud do
+  gem 'kitchen-sync'
+  gem 'kitchen-digitalocean', '~> 0.8'
+end


### PR DESCRIPTION
The current travis file attempts to run testing on Digital Ocean but it
cannot find the kitchen driver for Digitalocean. The kitchen-sync gem is
also required. 
