### PR TITLE
Flush internal package cache after module action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the yum cookbook.
 
 ## Unreleased
 
+- Add `flush_cache` option to `dnf_module`
+
 ## 7.2.1 - *2021-12-21*
 
 - Fix version comparison in `dnf_module` supported check

--- a/documentation/dnf_module.md
+++ b/documentation/dnf_module.md
@@ -17,10 +17,13 @@ These map to `dnf module` subcommands, documented [here](https://dnf.readthedocs
 
 ## Properties
 
-| Name          | Type                | Default       | Description                           |
-| ------------- | ------------------- | ------------- | ------------------------------------- |
-| `module_name` | `String`            | Resource name | Name of the module to install.        |
-| `options`     | `String` or `Array` |               | Any additional options to pass to DNF |
+| Name          | Type                | Default       | Description                                                     |
+| ------------- | ------------------- | ------------- | --------------------------------------------------------------- |
+| `module_name` | `String`            | Resource name | Name of the module to install.                                  |
+| `options`     | `String` or `Array` |               | Any additional options to pass to DNF                           |
+| `flush_cache` | `true`, `false`     | `true`        | Whether to flush the Chef package cache after the module action |
+
+Flushing Chef's package cache is needed when switching to a module stream added *during* the Chef run, e.g. from a new repo.
 
 ## Examples
 

--- a/spec/unit/resources/dnf_module_spec.rb
+++ b/spec/unit/resources/dnf_module_spec.rb
@@ -41,6 +41,9 @@ describe 'dnf_module' do
 
       # needed for test to run
       it { is_expected.to install_dnf_module('test:1.0') }
+
+      # test once here, works the same for all the other actions
+      it { is_expected.to flush_cache_package('flush package cache test:1.0') }
     end
 
     context 'when module is already installed' do
@@ -195,6 +198,22 @@ describe 'dnf_module' do
 
       it { is_expected.to reset_dnf_module('test:1.0') }
     end
+  end
+
+  context 'no cache flush' do
+    recipe do
+      dnf_module 'test:1.0' do
+        flush_cache false
+        action :install
+      end
+    end
+
+    stubs_for_provider('dnf_module[test:1.0]') do |provider|
+      allow(provider).to receive_shell_out('dnf -q module list', stdout: removed_disabled)
+      allow(provider).to receive_shell_out("dnf -qy module install  'test:1.0'")
+    end
+
+    it { is_expected.to_not flush_cache_package('flush package cache test:1.0') }
   end
 
   context 'noop on C7' do

--- a/test/cookbooks/test/metadata.rb
+++ b/test/cookbooks/test/metadata.rb
@@ -5,3 +5,4 @@ license 'Apache-2.0'
 version '1.0.0'
 
 depends 'yum'
+depends 'yum-remi-chef'

--- a/test/cookbooks/test/metadata.rb
+++ b/test/cookbooks/test/metadata.rb
@@ -1,4 +1,7 @@
 name 'test'
-version '0.1.0'
+maintainer 'Chef Software, Inc.'
+maintainer_email 'cookbooks@chef.io'
+license 'Apache-2.0'
+version '1.0.0'
 
 depends 'yum'

--- a/test/cookbooks/test/recipes/dnf_module.rb
+++ b/test/cookbooks/test/recipes/dnf_module.rb
@@ -9,3 +9,11 @@ end
 dnf_module 'mysql' do
   action :disable
 end
+
+# test cache flush
+yum_remi_modular 'default'
+dnf_module 'php:remi-8.1'
+
+# this would fail if cache is not reloaded
+# would still try to install stock php 7.2
+package 'php'

--- a/test/integration/dnf_module/inspec/module_spec.rb
+++ b/test/integration/dnf_module/inspec/module_spec.rb
@@ -1,3 +1,10 @@
+describe command('dnf module list') do
+  its('stdout') { should match /nodejs +12 \[e\]/ }
+  its('stdout') { should match /ruby +2.7 \[e\]/ }
+  its('stdout') { should match /php +remi-8.1 \[e\]/ }
+  its('stdout') { should match /mysql.+\[x\]/ }
+end
+
 describe command('node --version') do
   its('stdout') { should match /v12/ }
 end
@@ -6,6 +13,6 @@ describe command('ruby --version') do
   its('stdout') { should match /ruby 2.7/ }
 end
 
-describe command('dnf module list --disabled mysql') do
-  its('stdout') { should match /mysql.+\[x\]/ }
+describe command('php --version') do
+  its('stdout') { should match /PHP 8.1/ }
 end


### PR DESCRIPTION
# Description

After switching to a new module installed during the Chef run, Chef's internal package cache won't pick up on new module packages automatically, so we need to reload that manually, much like after adding a new repo.

This isn't needed for modules available at the start of the Chef run, which is why this was not needed for the existing tests with all default modules.

## Issues Resolved

None, but discovered as part of sous-chefs/yum-remi-chef#40

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
