### PR TITLE
Fix version comparison on platform_version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the yum cookbook.
 
 ## Unreleased
 
+- Fix version comparison in `dnf_module` supported check
+
 ## 7.2.0 - *2021-09-29*
 
 - Add `dnf_module` resource for managing DNF modules on RHEL 8+ / Fedora

--- a/resources/dnf_module.rb
+++ b/resources/dnf_module.rb
@@ -14,7 +14,7 @@ property :options, [String, Array],
 
 action_class do
   def supported?
-    (platform_family?('rhel') && node['platform_version'] >= 8) || platform?('fedora')
+    (platform_family?('rhel') && node['platform_version'].to_i >= 8) || platform?('fedora')
   end
 
   def list_modules(type)

--- a/spec/unit/resources/dnf_module_spec.rb
+++ b/spec/unit/resources/dnf_module_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'dnf_module' do
-  platform 'centos'
+  platform 'centos', '8'
   step_into :dnf_module
 
   installed_enabled = <<~EOF

--- a/test/cookbooks/test/metadata.rb
+++ b/test/cookbooks/test/metadata.rb
@@ -1,3 +1,4 @@
 name 'test'
+version '0.1.0'
 
 depends 'yum'


### PR DESCRIPTION
# Description

The supported platform check should be using `.to_i` instead of comparing to the original string value.

## Issues Resolved

(none)

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
