### PR TITLE
ignore kitchen.dokken.yml

### DIFF
--- a/chefignore
+++ b/chefignore
@@ -61,7 +61,7 @@ Dangerfile
 examples/*
 features/*
 Guardfile
-kitchen.yml*
+kitchen*.yml*
 mlc_config.json
 Procfile
 Rakefile


### PR DESCRIPTION
The `kitchen.dokken.yml` is being uploaded with the cookbook. This is unnecessary and slightly wasteful.